### PR TITLE
Fix / ssl tunneling

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -7,7 +7,7 @@ module.exports = {
     },
 
     NETWORK: {
-        SERVER_IP: 'http://X.X.X.X:3001'
+        SERVER_IP: 'https://TUNNELING_TEMPORARY_IP:3001'
     },
 
     LOADER: {

--- a/src/js/components/Code.jsx
+++ b/src/js/components/Code.jsx
@@ -24,7 +24,7 @@ module.exports = React.createClass({
      * @returns {String}
      */
     getCodeText: function () {
-        return Config.NETWORK.SERVER_IP+ '/app?type=' + this.props.type + '&version=' + this.props.version;
+        return Config.NETWORK.SERVER_IP+ '/application?type=' + this.props.type + '&version=' + this.props.version;
     },
 
     /**


### PR DESCRIPTION
# Additional info
iOS requires https connection to install *.ipa application directly from url. To achieve it, temporary tunneling connection was implemented by [ngrok](https://ngrok.com/)